### PR TITLE
just a minor markup change.

### DIFF
--- a/README.org
+++ b/README.org
@@ -322,7 +322,9 @@ Start XLaunch and use the defaults:
 Just make a shortcut to vcxsrv.exe in the installation folder and then changes
 its target to:
 
-~"C:\Program Files\VcXsrv\vcxsrv.exe" :0 -multiwindow -clipboard -wgl~
+#+BEGIN_SRC shell
+"C:\Program Files\VcXsrv\vcxsrv.exe" :0 -multiwindow -clipboard -wgl
+#+END_SRC
 
 You can put this link into the startup folder to start in when booting. And
 stick it to the task bar to launch it from there.


### PR DESCRIPTION
(first and foremost, thank you for your guide: it was priceless)

I changed the markup in the `README.org` because copy/pasting the shortcut change for `vcxsrv`, it refused to launch due the trailing tilde (should I have been more cautious? Yes, probably...)

But with this minor change, nobody would waste a second more than needed to benefit from your guide.