### PR TITLE
Added libjansson-dev as dependency to enable native json support

### DIFF
--- a/README.org
+++ b/README.org
@@ -256,7 +256,7 @@ This installs all dependencies for Emacs and then installs Emacs 26.3:
       librsvg2-dev libsm-dev libthai-dev libtiff5-dev libtiff-dev libtinfo-dev libtool \
       libx11-dev libxext-dev libxi-dev libxml2-dev libxmu-dev libxmuu-dev libxpm-dev \
       libxrandr-dev libxt-dev libxtst-dev libxv-dev quilt sharutils texinfo xaw3dg \
-      xaw3dg-dev xorg-dev xutils-dev zlib1g-dev
+      xaw3dg-dev xorg-dev xutils-dev zlib1g-dev libjansson-dev
 
   ## download and install
 


### PR DESCRIPTION
Native JSON support is enabled by default, but only takes effect if `libjansson-dev` (Debian) is installed.

See this [issue](https://github.com/emacs-lsp/lsp-mode/issues/1557#issuecomment-608409056) for more information.