### PR TITLE
Added libjansson-dev in Emacs 27 script for native JSON support.

### DIFF
--- a/emacs-27.sh
+++ b/emacs-27.sh
@@ -12,7 +12,7 @@ sudo apt install -y autoconf automake autotools-dev bsd-mailx build-essential \
     librsvg2-dev libsm-dev libthai-dev libtiff5-dev libtiff-dev libtinfo-dev libtool \
     libx11-dev libxext-dev libxi-dev libxml2-dev libxmu-dev libxmuu-dev libxpm-dev \
     libxrandr-dev libxt-dev libxtst-dev libxv-dev quilt sharutils texinfo xaw3dg \
-    xaw3dg-dev xorg-dev xutils-dev zlib1g-dev
+    xaw3dg-dev xorg-dev xutils-dev zlib1g-dev libjansson-dev
 
 ## download and install
 


### PR DESCRIPTION
This is needed to enable native JSON support. 

See https://github.com/hubisan/emacs-wsl/issues/17