### PR TITLE
Don't delete the directory where emacs was extracted or cloned to.

### DIFF
--- a/README.org
+++ b/README.org
@@ -221,13 +221,13 @@ This installs all dependencies for Emacs and then installs Emacs 26.3:
   ./configure
   make
   sudo make install
-
-  cd ~
-  rm -rf ~/emacs-26.3
   rm ~/emacs-26.3.tar.gz
 #+END_SRC
 
 See[[file:emacs-27.sh][ emacs-27.sh]] to install Emacs 27 instead.
+
+Keeps the directory where emacs was extracted or cloned to in case any step
+fails (to clean or reinstall) or to be able to reconfigure.
 
 * Run Emacs in terminal
 

--- a/emacs-27.sh
+++ b/emacs-27.sh
@@ -24,5 +24,3 @@ cd emacs
 ./configure
 make
 sudo make install
-cd ~
-rm -rf ~/emacs


### PR DESCRIPTION
Take away the lines that remove the directory where emacs was extracted or cloned to from the readme and the script.

This makes it possible to easily

- reconfigure the installation
- or clean the installation (see Makefile).