### PR TITLE
Added some dependencies from snap

### DIFF
--- a/README.org
+++ b/README.org
@@ -196,10 +196,10 @@ Restart WSL.
 
 * Install Emacs
 
-This installs all dependencies for Emacs and then installs Emacs 26.3:
+Install all dependencies for Emacs and then install Emacs 26.3:
 
 #+BEGIN_SRC shell
-  ## install dependencies (got those from all over the net)
+  ## install dependencies (got those from all over the net and from the snap)
 
   sudo apt install -y autoconf automake autotools-dev bsd-mailx build-essential \
       diffstat gnutls-dev imagemagick libasound2-dev libc6-dev libdatrie-dev \
@@ -210,7 +210,13 @@ This installs all dependencies for Emacs and then installs Emacs 26.3:
       libx11-dev libxext-dev libxi-dev libxml2-dev libxmu-dev libxmuu-dev libxpm-dev \
       libxrandr-dev libxt-dev libxtst-dev libxv-dev quilt sharutils texinfo xaw3dg \
       xaw3dg-dev xorg-dev xutils-dev zlib1g-dev libjansson-dev libxaw7-dev \
-      libselinux1-dev libmagick++-dev libacl1-dev
+      libselinux1-dev libmagick++-dev libacl1-dev gir1.2-javascriptcoregtk-4.0 \
+      gir1.2-webkit2-4.0 libenchant1c2a libglvnd-core-dev libicu-le-hb-dev \
+      libidn2-0-dev libjavascriptcoregtk-4.0-dev liboss4-salsa2 libsoup2.4-dev \
+      libsystemd-dev libwebkit2gtk-4.0-dev libx11-xcb-dev libxcb-dri2-0-dev \
+      libxcb-dri3-dev libxcb-glx0-dev libxcb-present-dev libxshmfence-dev \
+      x11proto-composite-dev x11proto-core-dev x11proto-damage-dev \
+      x11proto-fixes-dev
 
   ## download and install
 

--- a/emacs-27.sh
+++ b/emacs-27.sh
@@ -13,7 +13,13 @@ sudo apt install -y autoconf automake autotools-dev bsd-mailx build-essential \
     libx11-dev libxext-dev libxi-dev libxml2-dev libxmu-dev libxmuu-dev libxpm-dev \
     libxrandr-dev libxt-dev libxtst-dev libxv-dev quilt sharutils texinfo xaw3dg \
     xaw3dg-dev xorg-dev xutils-dev zlib1g-dev libjansson-dev libxaw7-dev \
-    libselinux1-dev libmagick++-dev libacl1-dev
+    libselinux1-dev libmagick++-dev libacl1-dev gir1.2-javascriptcoregtk-4.0 \
+    gir1.2-webkit2-4.0 libenchant1c2a libglvnd-core-dev libicu-le-hb-dev \
+    libidn2-0-dev libjavascriptcoregtk-4.0-dev liboss4-salsa2 libsoup2.4-dev \
+    libsystemd-dev libwebkit2gtk-4.0-dev libx11-xcb-dev libxcb-dri2-0-dev \
+    libxcb-dri3-dev libxcb-glx0-dev libxcb-present-dev libxshmfence-dev \
+    x11proto-composite-dev x11proto-core-dev x11proto-damage-dev \
+    x11proto-fixes-dev
 
 ## download and install
 


### PR DESCRIPTION
Was working flawless without before but maybe this will enable some
additional features someone might need.

Snap: https://snapcraft.io/emacs

Dependencies are taken from the buildlog:
https://launchpadlibrarian.net/491780563/
buildlog_snap_ubuntu_bionic_amd64_emacs-snapshot_BUILDING.txt.gz