### PR TITLE
Listen for TCP traffic with XLaunch method

### DIFF
--- a/README.org
+++ b/README.org
@@ -324,7 +324,7 @@ Start XLaunch and use the defaults:
 
 - Multiple Windows, Display number -1 (or 0 if not working), Next
 - Start no client, Next
-- Leave checkboxes, Next
+- Leave checkboxes, Additional parameters for X server: ~-listen tcp~, Next
 - Finish
 
 **** With a Shortcut


### PR DESCRIPTION
I ran into networking issues while following the XLaunch instructions. This adds the `-listen tcp` flag, which is already present in the shortcut method.