### PR TITLE
Fixes the alias to run Emacs in WSL 2

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+*** [[https://github.com/hubisan/emacs-wsl/compare/v1.1.2...v1.1.3][1.1.3]] - 2021-08-04
+
+**** Fixed
+- Fixed the alias to run Emacs for WSL 2.
+  
 *** [[https://github.com/hubisan/emacs-wsl/compare/v1.1.1...v1.1.2][1.1.2]] - 2021-07-08
 
 **** Added

--- a/README.org
+++ b/README.org
@@ -318,19 +318,19 @@ run Emacs with ~ema~ (needs a restart):
 
 - ~WSL 1~
   #+BEGIN_SRC shell
-    alias ema='
+    alias ema="
     export DISPLAY=:0.0
     export LIBGL_ALWAYS_INDIRECT=1
     setsid emacs
-    '
+    "
   #+END_SRC
 - ~WSL 2~
   #+BEGIN_SRC shell
-    alias ema='
+    alias ema="
     export DISPLAY=$(ip route | awk '/^default/{print $3; exit}'):0.0
     export LIBGL_ALWAYS_INDIRECT=1
     setsid emacs
-    '
+    "
   #+END_SRC
 
 * Optional Additions


### PR DESCRIPTION
Fixes the alias to run Emacs in WSL 2. Changed the surrounding `'` to `"` as the command includes a `'` and then the string is ended and the alias is not working.

Closes #47.