### PR TITLE
Add information on to keep alive X11 > Hyper-V connections

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -7,11 +7,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+*** [[https://github.com/hubisan/emacs-wsl/compare/v1.1.3...v1.1.4][1.1.4]] - 2021-09-20
+
+**** Added
+- Added multiple options to keep WSL2 Graphical Apps alive after sleep or hibernation
+
 *** [[https://github.com/hubisan/emacs-wsl/compare/v1.1.2...v1.1.3][1.1.3]] - 2021-08-04
 
 **** Fixed
 - Fixed the alias to run Emacs for WSL 2.
-  
+
 *** [[https://github.com/hubisan/emacs-wsl/compare/v1.1.1...v1.1.2][1.1.2]] - 2021-07-08
 
 **** Added

--- a/README.org
+++ b/README.org
@@ -335,6 +335,56 @@ run Emacs with ~ema~ (needs a restart):
 
 * Optional Additions
 
+** Preserve X11 Connections to Hyper-V
+The network connection between Windows and WSL2 breaks when your machine goes
+into standby or hibernate. Graphical Emacs & other GUI apps will terminate.
+
+Should you want to preserve your GUI Emacs sessions between sleep, there are
+three options:
+
+1. Use X2Go - virtual X11 server with Windows client
+
+   This is the most preferred option
+
+   a) Fix SSH host keys
+
+      #+begin_src bash
+      sudo apt-get remove --purge openssh-server
+      sudo apt-get install openssh-server
+      sudo service ssh --full-restart
+      #+end_src
+
+   b) Install X2Go on your Linux distribution
+
+      #+begin_src bash
+      apt install x2goserver
+      #+end_src
+
+   c) [[code.x2go.org/releases/X2GoClient_latest_mswin32-setup.exe][Download]] and install the client for Windows.
+
+   d) Configure the
+
+       Host: localhost
+       Login: <your user>
+       Session type: Published Applications
+
+   e) After each WSL/Windows restart
+
+      Launch ssh in Linux (if not started yet): sudo service ssh start
+      Launch “X2Go Client” on Windows ad connect to the server with user/password
+      Now you can launch X11 apps via the tray icon (see X2Go Published Applications)
+
+   Source: [[https://derkoe.dev/blog/development-environment-in-wsl2/][Development Environment in WSL2]]
+
+2. Forward X11 unix socket from WSL2 via WSL1 to X410/Vcxsrv/etc. running on Windows
+
+   [[http://emacsredux.com/blog/2020/09/23/using-emacs-on-windows-with-wsl2/?ht-comment-id=688089][Using Emacs on Windows with WSL2 | Emacs Redux]]
+   [[https://github.com/microsoft/WSL/issues/4619#issuecomment-678652118][microsoft/WSL#4619 {WSL 2} WSL 2 cannot access windows service via localhost:...]]
+
+3. WSL Daemon - Stable X11 connection for WSL2
+
+   [[https://github.com/nbdd0121/wsld][GitHub - nbdd0121/wsld: WSL Daemon - Stable X11 connection and time synchroni...]]
+
 ** Use Windows Terminal
 
 Install [[https://www.microsoft.com/en-us/p/windows-terminal/9n0dx20hk701?rtc=1&activetab=pivot:overviewtab][Windows Terminal]] from Microsoft from the Microsoft Store.
@@ -375,7 +425,7 @@ To change the default path to =~=:
 ** Change keyboard layout
 
 If you want to change the keyboard layout used make sure ~x11-xkb-utils~ is
-installed (~sudo apt install x11-xkb-utils~) and add for instance 
+installed (~sudo apt install x11-xkb-utils~) and add for instance
 
 #+BEGIN_SRC shell
   setxkbmap -layout us


### PR DESCRIPTION
Restarting your graphical Emacs after waking your computer from sleep or
hibernation can be a dealbreaker, especially if your custom configurations
take more than a few seconds to load. Terminal WSL2 Emacs stays alive, but you
sacrifice keyboard configuration and copy-paste ability.

Three methods have been added. Only two have been tested, the WSLD solution did
not work for myself but all three have been included for sake of completeness.

Thanks for your work on this guide!

By chance, do you happen to have working audio within WSL2?