### PR TITLE
Increase portability by swapping hardcoded path with environment variable

### DIFF
--- a/run-emacs-wsl-1/wsl-1_1-vcxsrv.bat
+++ b/run-emacs-wsl-1/wsl-1_1-vcxsrv.bat
@@ -1,2 +1,2 @@
 @rem Start VcXsrv
-start "" "C:\Program Files\VcXsrv\vcxsrv.exe" :0 -multiwindow -clipboard -wgl
+start "" "${Env:programfiles}\VcXsrv\vcxsrv.exe" :0 -multiwindow -clipboard -wgl

--- a/run-emacs-wsl-2/wsl-2_2-firewall-rule.ps1
+++ b/run-emacs-wsl-2/wsl-2_2-firewall-rule.ps1
@@ -13,7 +13,7 @@ if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]:
 Import-Module -Name 'NetSecurity'
 
 $rulename = 'WSL 2 Firewall Unlock'
-$programname = 'C:\program files\vcxsrv\vcxsrv.exe'
+$programname = '${Env:programfiles}\vcxsrv\vcxsrv.exe'
 $localport = 6000
 
 # Get the remote ip.

--- a/run-emacs-wsl-2/wsl-2_3-vcxsrv.bat
+++ b/run-emacs-wsl-2/wsl-2_3-vcxsrv.bat
@@ -1,2 +1,2 @@
 @rem Run VcXsrv
-start "" "C:\Program Files\VcXsrv\vcxsrv.exe" :0 -multiwindow -clipboard -wgl -ac
+start "" "${Env:programfiles}\VcXsrv\vcxsrv.exe" :0 -multiwindow -clipboard -wgl -ac

--- a/run-emacs-wsl-2/wsl-2_3-vcxsrv.ps1
+++ b/run-emacs-wsl-2/wsl-2_3-vcxsrv.ps1
@@ -15,4 +15,4 @@ if ($vcxsrv) {
 }
 
 # Start vcxsrv with the flags needed.
-& "C:\Program Files\VcXsrv\vcxsrv.exe" :0 -multiwindow -clipboard -wgl -ac
+& "${Env:programfiles}\VcXsrv\vcxsrv.exe" :0 -multiwindow -clipboard -wgl -ac


### PR DESCRIPTION
Replaced 'C:/Program files' with environment variable pointing to program files folder